### PR TITLE
fix: add prisma db push to vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "vercel-build": "prisma generate && next build",
+    "vercel-build": "prisma generate && prisma db push && next build",
     "prisma:generate": "prisma generate",
     "postinstall": "prisma generate",
     "fmt": "prettier --write ."


### PR DESCRIPTION
## Summary
Fixes 500 Internal Server Error by adding automatic database schema synchronization during Vercel deployment.

## Problem
After migrating to PostgreSQL, the database tables don't exist in production, causing:
```
The table `public.Url` does not exist in the current database.
```

## Solution
- Added `prisma db push` to the `vercel-build` script
- Now deployment automatically creates/syncs database schema before building

## Changes
- **package.json**: Updated `vercel-build` script to include `prisma db push`

## Flow
1. `prisma generate` - Generate Prisma client
2. `prisma db push` - Sync schema to PostgreSQL database 
3. `next build` - Build the application

This ensures the database tables are created automatically during every deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)