### PR TITLE
perf(realtime): use groupBy for unique visitor count

### DIFF
--- a/pages/api/realtime/metrics.ts
+++ b/pages/api/realtime/metrics.ts
@@ -42,7 +42,7 @@ export default async function handler(
           },
         },
       }),
-      // Get unique IPs using Prisma groupBy (more memory-efficient than findMany+distinct)
+      // Count unique IPs using Prisma groupBy (avoids loading full records into memory)
       prisma.pageView.groupBy({
         by: ['ip'],
         where: {
@@ -54,6 +54,7 @@ export default async function handler(
             notIn: [''],
           },
         },
+        _count: { _all: true },
       }),
     ])
 

--- a/pages/api/realtime/metrics.ts
+++ b/pages/api/realtime/metrics.ts
@@ -42,8 +42,9 @@ export default async function handler(
           },
         },
       }),
-      // Get unique IPs using Prisma distinct
-      prisma.pageView.findMany({
+      // Get unique IPs using Prisma groupBy (more memory-efficient than findMany+distinct)
+      prisma.pageView.groupBy({
+        by: ['ip'],
         where: {
           createdAt: {
             gte: last24Hours,
@@ -53,10 +54,6 @@ export default async function handler(
             notIn: [''],
           },
         },
-        select: {
-          ip: true,
-        },
-        distinct: ['ip'],
       }),
     ])
 


### PR DESCRIPTION
## Summary
- Replace `findMany` + `distinct` with `groupBy` for the unique IP query in the realtime metrics endpoint
- `groupBy` generates a `GROUP BY` SQL query handled server-side, avoiding loading all unique IP objects into Node.js memory
- No change to response shape or caching behavior

## Test plan
- [x] Type-check passes (`tsc --noEmit`)
- [x] Lint passes (`eslint`)
- [x] Unit tests pass (`vitest`)
- [ ] Verify realtime dashboard still shows correct unique visitor count

## Summary by Sourcery

Enhancements:
- Use a Prisma groupBy query for unique IP aggregation in the realtime metrics endpoint to reduce memory usage while preserving the response shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the metrics calculation query for improved performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->