### PR TITLE
redesign: unify dashboard UI/UX on shadcn design system

### DIFF
--- a/app/analytics/analytics-client.tsx
+++ b/app/analytics/analytics-client.tsx
@@ -10,14 +10,16 @@ import {
   BotTypeChart,
   TopBotsChart,
 } from '@/components/charts/BotChart';
-import { ChartTitle } from '@/components/charts/ChartTitle';
 import { DeviceChart } from '@/components/charts/DeviceChart';
 import GradientOrb from '@/components/charts/GradientOrb';
 import { LocationChart } from '@/components/charts/LocationChart';
 import { RadialDonutChart } from '@/components/charts/RadialDonutChart';
 import { MetricToggle, TrendsChart } from '@/components/charts/TrendsChart';
 import { DateRangePicker } from '@/components/DateRangePicker';
+import { PageHeader } from '@/components/PageHeader';
+import { SectionCard } from '@/components/SectionCard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Toggle } from '@/components/ui/toggle';
 import {
   useAudienceData,
   useBotsData,
@@ -111,45 +113,40 @@ export function AnalyticsClient() {
           <GradientOrb variant="teal" size={250} className="-top-10 -left-16" />
 
           {/* Header */}
-          <div className="relative flex flex-col space-y-3 md:flex-row md:items-center md:justify-between md:space-y-0">
-            <div>
-              <h1 className="text-xl font-normal tracking-tight text-foreground sm:text-2xl">
-                Analytics
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                {dateRange?.from && dateRange?.to && formatDateRange()}
-              </p>
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                onClick={() => setExcludeBots(!excludeBots)}
-                className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
-                  excludeBots
-                    ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:border-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300'
-                    : 'border-border bg-card text-foreground hover:bg-accent'
-                }`}
-              >
-                <Bot className="size-4" />
-                <span>{excludeBots ? 'Bots Excluded' : 'Include Bots'}</span>
-              </button>
-              <DateRangePicker value={dateRange} onChange={setDateRange} />
-            </div>
-          </div>
+          <PageHeader
+            title="Analytics"
+            description={dateRange?.from && dateRange?.to && formatDateRange()}
+            actions={
+              <>
+                <Toggle
+                  variant="outline"
+                  pressed={excludeBots}
+                  onPressedChange={setExcludeBots}
+                  aria-label="Exclude bot traffic"
+                  className="h-9 gap-2 bg-card px-3 shadow-none data-[state=on]:border-primary/40 data-[state=on]:bg-primary/10 data-[state=on]:text-primary"
+                >
+                  <Bot className="size-4" />
+                  <span>{excludeBots ? 'Bots Excluded' : 'Include Bots'}</span>
+                </Toggle>
+                <DateRangePicker value={dateRange} onChange={setDateRange} />
+              </>
+            }
+          />
 
           {/* Trends Chart */}
-          <div className="rounded-lg border border-border bg-card p-6">
-            <ChartTitle
-              title="Traffic Trends"
-              description="Page views and unique visitors over time"
-              loading={fetchingTrends}
-            >
+          <SectionCard
+            title="Traffic Trends"
+            description="Page views and unique visitors over time"
+            loading={fetchingTrends}
+            actions={
               <MetricToggle
                 activeMetric={activeMetric}
                 onMetricChange={setActiveMetric}
                 totalPageviews={trendsTotals.totalPageviews}
                 totalUniqueVisitors={trendsTotals.totalUniqueVisitors}
               />
-            </ChartTitle>
+            }
+          >
             <TrendsChart
               data={trendsData}
               loading={loadingTrends}
@@ -157,7 +154,7 @@ export function AnalyticsClient() {
               totalUniqueVisitors={trendsTotals.totalUniqueVisitors}
               activeMetric={activeMetric}
             />
-          </div>
+          </SectionCard>
 
           {/* Device, Location & Bot Analytics */}
           <Tabs defaultValue="devices" className="space-y-4">
@@ -178,149 +175,148 @@ export function AnalyticsClient() {
 
             <TabsContent value="devices" className="space-y-4">
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Browsers"
-                    description="Most popular"
-                    loading={fetchingDevices}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Browsers"
+                  description="Most popular"
+                  loading={fetchingDevices}
+                >
                   <DeviceChart
                     data={devicesData.browsers}
                     title="Browsers"
                     loading={loadingDevices}
                   />
-                </div>
+                </SectionCard>
 
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Operating Systems"
-                    description="Device OS"
-                    loading={fetchingDevices}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Operating Systems"
+                  description="Device OS"
+                  loading={fetchingDevices}
+                >
                   <DeviceChart
                     data={devicesData.os}
                     title="Operating Systems"
                     loading={loadingDevices}
                   />
-                </div>
+                </SectionCard>
 
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Device Types"
-                    description="Desktop, mobile, tablet"
-                    loading={fetchingDevices}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Device Types"
+                  description="Desktop, mobile, tablet"
+                  loading={fetchingDevices}
+                >
                   <RadialDonutChart
                     data={devicesData.devices}
                     title="Device Types"
                     loading={loadingDevices}
                     centerLabel="Devices"
                   />
-                </div>
+                </SectionCard>
               </div>
             </TabsContent>
 
             <TabsContent value="locations" className="space-y-4">
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Top Countries"
-                    description="Visitors by country"
-                    loading={fetchingLocations}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Top Countries"
+                  description="Visitors by country"
+                  loading={fetchingLocations}
+                >
                   <LocationChart
                     data={locationsData.countries}
                     title="Countries"
                     loading={loadingLocations}
                   />
-                </div>
+                </SectionCard>
 
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Top Cities"
-                    description="Visitors by city"
-                    loading={fetchingLocations}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Top Cities"
+                  description="Visitors by city"
+                  loading={fetchingLocations}
+                >
                   <LocationChart
                     data={locationsData.cities}
                     title="Cities"
                     loading={loadingLocations}
                   />
-                </div>
+                </SectionCard>
               </div>
             </TabsContent>
 
             <TabsContent value="audience" className="space-y-4">
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="UTM Campaigns"
-                    description="Traffic by UTM campaign"
-                    loading={fetchingAudience}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="UTM Campaigns"
+                  description="Traffic by UTM campaign"
+                  loading={fetchingAudience}
+                >
                   <AudienceListChart
                     data={audienceResult?.utmCampaigns || []}
                     title="Campaigns"
                     loading={loadingAudience}
                   />
-                </div>
+                </SectionCard>
 
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Languages"
-                    description="Browser locale preferences"
-                    loading={fetchingAudience}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Languages"
+                  description="Browser locale preferences"
+                  loading={fetchingAudience}
+                >
                   <AudienceListChart
                     data={audienceResult?.languages || []}
                     title="Languages"
                     loading={loadingAudience}
                   />
-                </div>
+                </SectionCard>
 
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Screen Resolutions"
-                    description="Viewport width & height"
-                    loading={fetchingAudience}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Screen Resolutions"
+                  description="Viewport width & height"
+                  loading={fetchingAudience}
+                >
                   <AudienceListChart
                     data={audienceResult?.viewports || []}
                     title="Resolutions"
                     loading={loadingAudience}
                   />
-                </div>
+                </SectionCard>
               </div>
             </TabsContent>
 
             <TabsContent value="bots" className="space-y-4">
-              <div className="rounded-lg border border-border bg-card p-6">
-                <ChartTitle
-                  title="Bot vs Human Traffic"
-                  description="Traffic breakdown by source type"
-                  loading={fetchingBots}
-                />
+              <SectionCard
+                title="Bot vs Human Traffic"
+                description="Traffic breakdown by source type"
+                loading={fetchingBots}
+              >
                 <BotOverviewChart data={botsResult} loading={loadingBots} />
-              </div>
+              </SectionCard>
 
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Bot Types"
-                    description="Distribution by bot category"
-                    loading={fetchingBots}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Bot Types"
+                  description="Distribution by bot category"
+                  loading={fetchingBots}
+                >
                   <BotTypeChart data={botsResult} loading={loadingBots} />
-                </div>
+                </SectionCard>
 
-                <div className="rounded-lg border border-border bg-card p-4">
-                  <ChartTitle
-                    title="Top Bots"
-                    description="Most active bot agents"
-                    loading={fetchingBots}
-                  />
+                <SectionCard
+                  padding="md"
+                  title="Top Bots"
+                  description="Most active bot agents"
+                  loading={fetchingBots}
+                >
                   <TopBotsChart data={botsResult} loading={loadingBots} />
-                </div>
+                </SectionCard>
               </div>
             </TabsContent>
           </Tabs>

--- a/app/homepage-client.tsx
+++ b/app/homepage-client.tsx
@@ -8,7 +8,6 @@ import {
   ArrowUpDown,
   BarChart3,
   ChevronDown,
-  ChevronUp,
   Clock,
   Globe,
   Link as LinkIcon,
@@ -20,9 +19,9 @@ import {
 import Link from 'next/link';
 import { useState } from 'react';
 import { AnimatedNumber } from '@/components/AnimatedNumber';
-import { ChartTitle } from '@/components/charts/ChartTitle';
 import { MetricToggle, TrendsChart } from '@/components/charts/TrendsChart';
 import { EmptyState } from '@/components/EmptyState';
+import { SectionCard } from '@/components/SectionCard';
 import { Usage } from '@/components/Usage';
 import { Input } from '@/components/ui/input';
 import {
@@ -34,6 +33,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useTrendsData } from '@/hooks/useAnalytics';
+import { cn } from '@/lib/utils';
 
 type DomainStat = {
   hostId: number;
@@ -207,45 +207,50 @@ export function HomepageClient({
             className="grid grid-cols-1 gap-4 sm:grid-cols-3"
           >
             <motion.div variants={item}>
-              <div className="rounded-lg border border-border bg-card p-4 transition-colors hover:border-border/80">
+              <SectionCard
+                padding="md"
+                className="transition-colors hover:border-border/80"
+              >
                 <div className="mb-2 flex items-center gap-2">
                   <BarChart3 className="size-4 text-muted-foreground" />
                   <span className="text-sm text-muted-foreground">
                     Total Views
                   </span>
                 </div>
-                <div className="text-xl font-medium text-foreground sm:text-2xl">
+                <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
                   <AnimatedNumber value={totalPageViews} separator="," />
                 </div>
-              </div>
+              </SectionCard>
             </motion.div>
 
             <motion.div variants={item}>
-              <div className="rounded-lg border border-border bg-card p-4 transition-colors hover:border-border/80">
+              <SectionCard
+                padding="md"
+                className="transition-colors hover:border-border/80"
+              >
                 <div className="mb-2 flex items-center gap-2">
                   <Globe className="size-4 text-muted-foreground" />
-                  <span className="text-sm text-muted-foreground">
-                    Domains
-                  </span>
+                  <span className="text-sm text-muted-foreground">Domains</span>
                 </div>
-                <div className="text-xl font-medium text-foreground sm:text-2xl">
+                <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
                   <AnimatedNumber value={domainStats.length} />
                 </div>
-              </div>
+              </SectionCard>
             </motion.div>
 
             <motion.div variants={item}>
-              <div className="rounded-lg border border-border bg-card p-4 transition-colors hover:border-border/80">
+              <SectionCard
+                padding="md"
+                className="transition-colors hover:border-border/80"
+              >
                 <div className="mb-2 flex items-center gap-2">
                   <LinkIcon className="size-4 text-muted-foreground" />
-                  <span className="text-sm text-muted-foreground">
-                    URLs
-                  </span>
+                  <span className="text-sm text-muted-foreground">URLs</span>
                 </div>
-                <div className="text-xl font-medium text-foreground sm:text-2xl">
+                <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
                   <AnimatedNumber value={totalUrls} separator="," />
                 </div>
-              </div>
+              </SectionCard>
             </motion.div>
           </motion.div>
         </div>
@@ -254,19 +259,19 @@ export function HomepageClient({
       {/* Traffic Trends Chart */}
       <section>
         <div className="mx-auto max-w-4xl p-4 sm:px-6">
-          <div className="rounded-lg border border-border bg-card p-6">
-            <ChartTitle
-              title="Traffic Trends"
-              description="Page views and unique visitors over the last 30 days"
-              loading={fetchingTrends}
-            >
+          <SectionCard
+            title="Traffic Trends"
+            description="Page views and unique visitors over the last 30 days"
+            loading={fetchingTrends}
+            actions={
               <MetricToggle
                 activeMetric={activeMetric}
                 onMetricChange={setActiveMetric}
                 totalPageviews={trendsTotals.totalPageviews}
                 totalUniqueVisitors={trendsTotals.totalUniqueVisitors}
               />
-            </ChartTitle>
+            }
+          >
             <TrendsChart
               data={trendsData}
               loading={loadingTrends}
@@ -274,7 +279,7 @@ export function HomepageClient({
               totalUniqueVisitors={trendsTotals.totalUniqueVisitors}
               activeMetric={activeMetric}
             />
-          </div>
+          </SectionCard>
         </div>
       </section>
 
@@ -284,7 +289,11 @@ export function HomepageClient({
           <div className="rounded-lg border border-border bg-card">
             <button
               onClick={() => setIsIntegrationOpen(!isIntegrationOpen)}
-              className="flex w-full items-center justify-between p-6 text-left transition-colors hover:bg-accent"
+              aria-expanded={isIntegrationOpen}
+              className={cn(
+                'flex w-full items-center justify-between p-6 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                isIntegrationOpen ? 'rounded-t-lg' : 'rounded-lg',
+              )}
             >
               <div>
                 <h2 className="text-sm font-medium text-foreground sm:text-base">
@@ -296,11 +305,12 @@ export function HomepageClient({
                   backend
                 </p>
               </div>
-              {isIntegrationOpen ? (
-                <ChevronUp className="size-5 shrink-0 text-muted-foreground" />
-              ) : (
-                <ChevronDown className="size-5 shrink-0 text-muted-foreground" />
-              )}
+              <ChevronDown
+                className={cn(
+                  'size-5 shrink-0 text-muted-foreground transition-transform',
+                  isIntegrationOpen && 'rotate-180',
+                )}
+              />
             </button>
             {isIntegrationOpen && (
               <div className="border-t border-border p-6 pt-4">
@@ -361,7 +371,7 @@ export function HomepageClient({
                     <TableHead className="h-10 text-sm">
                       <button
                         onClick={() => handleSort('domain')}
-                        className="inline-flex items-center font-medium hover:text-foreground"
+                        className="-mx-1.5 inline-flex items-center rounded-md px-1.5 py-1.5 font-medium hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         Domain
                         <SortIcon column="domain" />
@@ -370,7 +380,7 @@ export function HomepageClient({
                     <TableHead className="h-10 text-right text-sm">
                       <button
                         onClick={() => handleSort('urls')}
-                        className="ml-auto inline-flex items-center font-medium hover:text-foreground"
+                        className="-mx-1.5 ml-auto inline-flex items-center rounded-md px-1.5 py-1.5 font-medium hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         URLs
                         <SortIcon column="urls" />
@@ -379,7 +389,7 @@ export function HomepageClient({
                     <TableHead className="h-10 text-right text-sm">
                       <button
                         onClick={() => handleSort('pageviews')}
-                        className="ml-auto inline-flex items-center font-medium hover:text-foreground"
+                        className="-mx-1.5 ml-auto inline-flex items-center rounded-md px-1.5 py-1.5 font-medium hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         Pageviews
                         <SortIcon column="pageviews" />
@@ -402,8 +412,8 @@ export function HomepageClient({
                             {/* eslint-disable-next-line @next/next/no-img-element */}
                             <img
                               src={`https://www.google.com/s2/favicons?sz=128&domain=${hostName}`}
-                              alt={hostName}
-                              className="size-5 rounded"
+                              alt=""
+                              className="size-5 rounded outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
                             />
                             <div className="flex flex-col">
                               <span className="text-sm font-medium text-foreground hover:text-primary">
@@ -418,10 +428,10 @@ export function HomepageClient({
                             </div>
                           </Link>
                         </TableCell>
-                        <TableCell className="py-3 text-right text-sm text-muted-foreground">
+                        <TableCell className="py-3 text-right text-sm tabular-nums text-muted-foreground">
                           {row._count}
                         </TableCell>
-                        <TableCell className="py-3 text-right text-sm font-medium text-foreground">
+                        <TableCell className="py-3 text-right text-sm font-medium tabular-nums text-foreground">
                           {row.pageViews?.toLocaleString() || 0}
                         </TableCell>
                         <TableCell className="py-3 text-right">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,13 +12,21 @@ export const metadata: Metadata = {
   },
 };
 
+// Applies the persisted (or system) theme before first paint to avoid a
+// flash of the wrong theme. Kept dependency-free on purpose.
+const themeInitScript = `(function(){try{var t=localStorage.getItem('theme');var d=t?t==='dark':window.matchMedia('(prefers-color-scheme: dark)').matches;if(d)document.documentElement.classList.add('dark');}catch(e){}})();`;
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Static theme bootstrap (no user input) — runs before first paint */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="min-h-screen bg-background font-[system-ui,_-apple-system,_BlinkMacSystemFont,_'Segoe_UI',_Roboto,_'Helvetica_Neue',_Arial,_sans-serif]">
         <Providers>{children}</Providers>
       </body>

--- a/app/realtime/realtime-client.tsx
+++ b/app/realtime/realtime-client.tsx
@@ -22,7 +22,9 @@ import { Button } from '@/components/ui/button';
 import { useRealtimeMetrics } from '@/hooks/useRealtimeMetrics';
 
 export function RealtimeClient() {
-  const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
+  // Starts null so the server and first client render match (a Date created
+  // during render differs between them and caused a hydration failure).
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const { metrics, loading, error, isConnected, refetch } =
     useRealtimeMetrics(30000); // 30 seconds
 
@@ -153,7 +155,9 @@ export function RealtimeClient() {
           {/* Status Footer */}
           <SectionCard padding="md">
             <div className="flex items-center justify-between text-sm text-muted-foreground">
-              <div>Updated: {lastUpdated.toLocaleTimeString()}</div>
+              <div>
+                Updated: {lastUpdated ? lastUpdated.toLocaleTimeString() : '—'}
+              </div>
               <div>Auto-refresh: 30s</div>
             </div>
           </SectionCard>

--- a/app/realtime/realtime-client.tsx
+++ b/app/realtime/realtime-client.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { RefreshCw, Wifi, WifiOff } from 'lucide-react';
+import { AlertCircle, RefreshCw, WifiOff } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import GradientOrb from '@/components/charts/GradientOrb';
 import { LocationMap } from '@/components/charts/LocationMap';
 import { RealtimeChart } from '@/components/charts/RealtimeChart';
+import { PageHeader } from '@/components/PageHeader';
 import {
   ActivePagesCard,
   CountriesCard,
@@ -15,6 +16,7 @@ import {
   ActivePagesTable,
   RecentCountriesTable,
 } from '@/components/RealtimeTable';
+import { SectionCard } from '@/components/SectionCard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useRealtimeMetrics } from '@/hooks/useRealtimeMetrics';
@@ -46,49 +48,54 @@ export function RealtimeClient() {
           />
 
           {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-xl font-normal tracking-tight text-foreground sm:text-2xl">
-                Real-time
-              </h1>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Last 24 hours live monitoring
-              </p>
-            </div>
-            <div className="flex items-center space-x-3">
-              <div className="flex items-center space-x-2">
+          <PageHeader
+            title="Real-time"
+            description="Last 24 hours live monitoring"
+            actions={
+              <>
                 {isConnected ? (
-                  <Wifi className="size-4 text-green-600" />
+                  <Badge
+                    variant="outline"
+                    className="h-7 gap-1.5 bg-card px-2.5 text-xs font-medium"
+                  >
+                    <span className="relative flex size-1.5">
+                      <span className="absolute inline-flex size-full animate-ping rounded-full bg-chart-2 opacity-75" />
+                      <span className="relative inline-flex size-1.5 rounded-full bg-chart-2" />
+                    </span>
+                    Live
+                  </Badge>
                 ) : (
-                  <WifiOff className="size-4 text-red-600" />
+                  <Badge
+                    variant="destructive"
+                    className="h-7 gap-1.5 px-2.5 text-xs"
+                  >
+                    <WifiOff className="size-3" />
+                    Offline
+                  </Badge>
                 )}
-                <Badge
-                  variant={isConnected ? 'default' : 'destructive'}
-                  className="h-6 px-2 text-xs"
+                <Button
+                  onClick={handleRefresh}
+                  disabled={loading}
+                  size="sm"
+                  variant="outline"
+                  className="h-8 px-3 text-sm"
                 >
-                  {isConnected ? 'Live' : 'Offline'}
-                </Badge>
-              </div>
-              <Button
-                onClick={handleRefresh}
-                disabled={loading}
-                size="sm"
-                variant="outline"
-                className="h-8 px-3 text-sm"
-              >
-                <RefreshCw
-                  className={`mr-1.5 size-4 ${loading ? 'animate-spin' : ''}`}
-                />
-                Refresh
-              </Button>
-            </div>
-          </div>
+                  <RefreshCw
+                    className={`mr-1.5 size-4 ${loading ? 'animate-spin' : ''}`}
+                  />
+                  Refresh
+                </Button>
+              </>
+            }
+          />
 
           {error && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:bg-red-950/20">
-              <div className="text-sm text-red-600 dark:text-red-400">
-                Error: {error}
-              </div>
+            <div
+              role="alert"
+              className="flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+            >
+              <AlertCircle className="size-4 shrink-0" />
+              <span>Error: {error}</span>
             </div>
           )}
 
@@ -110,36 +117,26 @@ export function RealtimeClient() {
           </div>
 
           {/* Real-time Chart */}
-          <div className="rounded-lg border border-border bg-card p-6">
-            <div className="mb-4">
-              <h2 className="text-sm font-medium text-foreground sm:text-base">
-                Hourly Traffic (Last 24h)
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                Real-time traffic patterns
-              </p>
-            </div>
+          <SectionCard
+            title="Hourly Traffic (Last 24h)"
+            description="Real-time traffic patterns"
+          >
             <RealtimeChart
               data={metrics?.hourlyViews || []}
               loading={loading}
             />
-          </div>
+          </SectionCard>
 
           {/* Location Map */}
-          <div className="rounded-lg border border-border bg-card p-6">
-            <div className="mb-4">
-              <h2 className="text-sm font-medium text-foreground sm:text-base">
-                Visitor Locations (Last Hour)
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                Geographic distribution of recent visitors
-              </p>
-            </div>
+          <SectionCard
+            title="Visitor Locations (Last Hour)"
+            description="Geographic distribution of recent visitors"
+          >
             <LocationMap
               data={metrics?.recentCountries || []}
               loading={loading}
             />
-          </div>
+          </SectionCard>
 
           {/* Data Tables */}
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -154,12 +151,12 @@ export function RealtimeClient() {
           </div>
 
           {/* Status Footer */}
-          <div className="rounded-lg border border-border bg-card p-4">
+          <SectionCard padding="md">
             <div className="flex items-center justify-between text-sm text-muted-foreground">
               <div>Updated: {lastUpdated.toLocaleTimeString()}</div>
               <div>Auto-refresh: 30s</div>
             </div>
-          </div>
+          </SectionCard>
         </div>
       </div>
     </div>

--- a/app/url/[urlId]/url-client.tsx
+++ b/app/url/[urlId]/url-client.tsx
@@ -2,12 +2,12 @@
 
 import type { Host, Url } from '@prisma/client';
 import { subDays } from 'date-fns';
-import { ArrowLeft, Calendar, ExternalLink, TrendingUp } from 'lucide-react';
-import Link from 'next/link';
+import { Calendar, ExternalLink, TrendingUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { DateRange } from 'react-day-picker';
+import { PageHeader } from '@/components/PageHeader';
+import { SectionCard } from '@/components/SectionCard';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { UrlAnalyticsSection } from '@/components/url/UrlAnalyticsSection';
 import { UrlTrendsSection } from '@/components/url/UrlTrendsSection';
@@ -50,14 +50,46 @@ function StatBar({ name, count, percentage }: StatItem) {
       <div className="flex items-center justify-between text-sm">
         <span className="font-medium">{name || 'Unknown'}</span>
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground">{count}</span>
-          <Badge variant="secondary" className="text-xs">
+          <span className="tabular-nums text-muted-foreground">{count}</span>
+          <Badge variant="secondary" className="text-xs tabular-nums">
             {percentage}%
           </Badge>
         </div>
       </div>
       <Progress value={percentage} className="h-2" />
     </div>
+  );
+}
+
+function StatBarCard({
+  title,
+  description,
+  items,
+  className,
+  columns = 1,
+}: {
+  title: string;
+  description: string;
+  items: StatItem[];
+  className?: string;
+  columns?: 1 | 2;
+}) {
+  return (
+    <SectionCard title={title} description={description} className={className}>
+      {items.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No data available
+        </p>
+      ) : (
+        <div
+          className={columns === 2 ? 'grid gap-4 md:grid-cols-2' : 'space-y-4'}
+        >
+          {items.map((item, idx) => (
+            <StatBar key={idx} {...item} />
+          ))}
+        </div>
+      )}
+    </SectionCard>
   );
 }
 
@@ -98,47 +130,36 @@ export function UrlClient({
       <div className="mx-auto max-w-4xl p-4 sm:px-6">
         <div className="flex flex-col space-y-4">
           {/* Header */}
-          <div>
-            <Link href={`/domain/${url.host.host}`}>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="mb-4 h-8 px-2 text-sm"
+          <PageHeader
+            title="URL Analytics"
+            description={
+              <a
+                href={url.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 break-all font-mono hover:text-foreground"
               >
-                <ArrowLeft className="mr-2 size-4" />
-                Back to {url.host.host}
-              </Button>
-            </Link>
-
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <h1 className="mb-2 text-xl font-normal tracking-tight text-foreground sm:text-2xl">
-                  URL Analytics
-                </h1>
-                <a
-                  href={url.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 break-all font-mono text-sm text-muted-foreground hover:text-foreground"
-                >
-                  {url.url}
-                  <ExternalLink className="size-3 shrink-0" />
-                </a>
-              </div>
+                {url.url}
+                <ExternalLink className="size-3 shrink-0" />
+              </a>
+            }
+            backHref={`/domain/${url.host.host}`}
+            backLabel={`Back to ${url.host.host}`}
+            actions={
               <div className="text-right">
-                <div className="text-xl font-medium text-foreground sm:text-2xl">
+                <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
                   {pageviewStats._count.toLocaleString()}
                 </div>
                 <div className="text-sm text-muted-foreground">
                   Total Pageviews
                 </div>
               </div>
-            </div>
-          </div>
+            }
+          />
 
           {/* Stats Summary */}
           <div className="grid gap-4 md:grid-cols-3">
-            <div className="rounded-lg border border-border bg-card p-4">
+            <SectionCard padding="md">
               <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
                 <Calendar className="size-4" />
                 First Seen
@@ -155,19 +176,19 @@ export function UrlClient({
                   )}
                 </p>
               )}
-            </div>
+            </SectionCard>
 
-            <div className="rounded-lg border border-border bg-card p-4">
+            <SectionCard padding="md">
               <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
                 <TrendingUp className="size-4" />
                 Total Pageviews
               </div>
-              <div className="text-xl font-medium text-foreground sm:text-2xl">
+              <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
                 {pageviewStats._count.toLocaleString()}
               </div>
-            </div>
+            </SectionCard>
 
-            <div className="rounded-lg border border-border bg-card p-4">
+            <SectionCard padding="md">
               <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
                 <Calendar className="size-4" />
                 Last Seen
@@ -184,7 +205,7 @@ export function UrlClient({
                   )}
                 </p>
               )}
-            </div>
+            </SectionCard>
           </div>
 
           {/* Traffic Trends Chart */}
@@ -203,118 +224,33 @@ export function UrlClient({
 
           {/* Legacy Analytics Grid */}
           <div className="grid gap-4 md:grid-cols-2">
-            {/* Top Countries */}
-            <div className="rounded-lg border border-border bg-card p-6">
-              <div className="mb-4">
-                <h2 className="text-sm font-medium text-foreground sm:text-base">
-                  Top Countries
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Geographic distribution of visitors
-                </p>
-              </div>
-              {topCountries.length === 0 ? (
-                <p className="py-6 text-center text-sm text-muted-foreground">
-                  No data available
-                </p>
-              ) : (
-                <div className="space-y-4">
-                  {topCountries.map((item, idx) => (
-                    <StatBar key={idx} {...item} />
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Top Browsers */}
-            <div className="rounded-lg border border-border bg-card p-6">
-              <div className="mb-4">
-                <h2 className="text-sm font-medium text-foreground sm:text-base">
-                  Top Browsers
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Browser distribution
-                </p>
-              </div>
-              {topBrowsers.length === 0 ? (
-                <p className="py-6 text-center text-sm text-muted-foreground">
-                  No data available
-                </p>
-              ) : (
-                <div className="space-y-4">
-                  {topBrowsers.map((item, idx) => (
-                    <StatBar key={idx} {...item} />
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Top Operating Systems */}
-            <div className="rounded-lg border border-border bg-card p-6">
-              <div className="mb-4">
-                <h2 className="text-sm font-medium text-foreground sm:text-base">
-                  Top Operating Systems
-                </h2>
-                <p className="text-sm text-muted-foreground">OS distribution</p>
-              </div>
-              {topOS.length === 0 ? (
-                <p className="py-6 text-center text-sm text-muted-foreground">
-                  No data available
-                </p>
-              ) : (
-                <div className="space-y-4">
-                  {topOS.map((item, idx) => (
-                    <StatBar key={idx} {...item} />
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Top Devices */}
-            <div className="rounded-lg border border-border bg-card p-6">
-              <div className="mb-4">
-                <h2 className="text-sm font-medium text-foreground sm:text-base">
-                  Top Devices
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Device type distribution
-                </p>
-              </div>
-              {topDevices.length === 0 ? (
-                <p className="py-6 text-center text-sm text-muted-foreground">
-                  No data available
-                </p>
-              ) : (
-                <div className="space-y-4">
-                  {topDevices.map((item, idx) => (
-                    <StatBar key={idx} {...item} />
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Top Engines */}
-            <div className="rounded-lg border border-border bg-card p-6 md:col-span-2">
-              <div className="mb-4">
-                <h2 className="text-sm font-medium text-foreground sm:text-base">
-                  Top Browser Engines
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Rendering engine distribution
-                </p>
-              </div>
-              {topEngines.length === 0 ? (
-                <p className="py-6 text-center text-sm text-muted-foreground">
-                  No data available
-                </p>
-              ) : (
-                <div className="grid gap-4 md:grid-cols-2">
-                  {topEngines.map((item, idx) => (
-                    <StatBar key={idx} {...item} />
-                  ))}
-                </div>
-              )}
-            </div>
+            <StatBarCard
+              title="Top Countries"
+              description="Geographic distribution of visitors"
+              items={topCountries}
+            />
+            <StatBarCard
+              title="Top Browsers"
+              description="Browser distribution"
+              items={topBrowsers}
+            />
+            <StatBarCard
+              title="Top Operating Systems"
+              description="OS distribution"
+              items={topOS}
+            />
+            <StatBarCard
+              title="Top Devices"
+              description="Device type distribution"
+              items={topDevices}
+            />
+            <StatBarCard
+              title="Top Browser Engines"
+              description="Rendering engine distribution"
+              items={topEngines}
+              className="md:col-span-2"
+              columns={2}
+            />
           </div>
         </div>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { DataSourceSelector } from './DataSourceSelector';
+import { ThemeToggle } from './ThemeToggle';
 
 export const Header = () => {
   const pathname = usePathname();
@@ -67,6 +68,8 @@ export const Header = () => {
 
             {/* Global database source selector */}
             <DataSourceSelector />
+
+            <ThemeToggle />
           </div>
         </div>
       </div>

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -1,0 +1,64 @@
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface PageHeaderProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Optional back navigation rendered above the title */
+  backHref?: string;
+  backLabel?: string;
+  /** Right-aligned header controls (status badges, pickers, buttons, ...) */
+  actions?: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared page heading used by every dashboard page so titles, descriptions,
+ * back-links, and header actions share one consistent treatment.
+ */
+export function PageHeader({
+  title,
+  description,
+  backHref,
+  backLabel = 'Back',
+  actions,
+  className,
+  children,
+}: PageHeaderProps) {
+  return (
+    <div className={cn('relative', className)}>
+      {backHref && (
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          className="-ml-2 mb-4 h-8 px-2 text-sm"
+        >
+          <Link href={backHref}>
+            <ArrowLeft className="mr-2 size-4" />
+            {backLabel}
+          </Link>
+        </Button>
+      )}
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-xl font-normal tracking-tight text-foreground sm:text-2xl">
+            {title}
+          </h1>
+          {description && (
+            <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+          )}
+        </div>
+        {actions && (
+          <div className="flex shrink-0 flex-wrap items-center gap-3">
+            {actions}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/components/RealtimeMetricCard.tsx
+++ b/components/RealtimeMetricCard.tsx
@@ -1,5 +1,6 @@
 import { Activity, Eye, Globe, Users } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { SectionCard } from '@/components/SectionCard';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface MetricCardProps {
   title: string;
@@ -18,43 +19,33 @@ export function RealtimeMetricCard({
   trend = 'neutral',
   loading,
 }: MetricCardProps) {
-  if (loading) {
-    return (
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">{title}</CardTitle>
-          {icon}
-        </CardHeader>
-        <CardContent>
-          <div className="h-6 animate-pulse rounded bg-muted"></div>
-          {change && (
-            <div className="mt-1 h-4 animate-pulse rounded bg-muted"></div>
-          )}
-        </CardContent>
-      </Card>
-    );
-  }
-
   const trendColor =
     trend === 'up'
-      ? 'text-teal-700'
+      ? 'text-chart-2'
       : trend === 'down'
-        ? 'text-orange-700'
+        ? 'text-chart-3'
         : 'text-muted-foreground';
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+    <SectionCard padding="md">
+      <div className="mb-2 flex items-center gap-2">
         {icon}
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-bold">
-          {typeof value === 'number' ? value.toLocaleString() : value}
-        </div>
-        {change && <p className={`text-xs ${trendColor} mt-1`}>{change}</p>}
-      </CardContent>
-    </Card>
+        <span className="text-sm text-muted-foreground">{title}</span>
+      </div>
+      {loading ? (
+        <>
+          <Skeleton className="h-7 w-20 sm:h-8" />
+          {change && <Skeleton className="mt-1 h-4 w-14" />}
+        </>
+      ) : (
+        <>
+          <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
+            {typeof value === 'number' ? value.toLocaleString() : value}
+          </div>
+          {change && <p className={`mt-1 text-xs ${trendColor}`}>{change}</p>}
+        </>
+      )}
+    </SectionCard>
   );
 }
 

--- a/components/RealtimeTable.tsx
+++ b/components/RealtimeTable.tsx
@@ -1,5 +1,6 @@
+import { SectionCard } from '@/components/SectionCard';
+import { Skeleton } from '@/components/ui/skeleton';
 import type { RealtimeMetrics } from '../types/socket';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import {
   Table,
   TableBody,
@@ -11,6 +12,7 @@ import {
 
 interface RealtimeTableProps {
   title: string;
+  description?: string;
   data: Array<{
     name?: string;
     path?: string;
@@ -24,58 +26,34 @@ interface RealtimeTableProps {
 
 export function RealtimeTable({
   title,
+  description,
   data,
   loading,
   emptyMessage = 'No data available',
 }: RealtimeTableProps) {
-  if (loading) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>{title}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2">
-            {[...Array(5)].map((_, i) => (
-              <div key={i} className="flex items-center justify-between">
-                <div className="mr-4 h-4 flex-1 animate-pulse rounded bg-muted"></div>
-                <div className="h-4 w-12 animate-pulse rounded bg-muted"></div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  if (!data || data.length === 0) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>{title}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="py-8 text-center text-muted-foreground">
-            {emptyMessage}
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <SectionCard title={title} description={description}>
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="flex items-center justify-between gap-4">
+              <Skeleton className="h-4 flex-1" />
+              <Skeleton className="h-4 w-12" />
+            </div>
+          ))}
+        </div>
+      ) : !data || data.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          {emptyMessage}
+        </p>
+      ) : (
         <Table>
           <TableHeader>
-            <TableRow>
-              <TableHead>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="h-10 text-sm">
                 {data[0]?.path ? 'Page' : data[0]?.country ? 'Country' : 'Item'}
               </TableHead>
-              <TableHead className="text-right">
+              <TableHead className="h-10 text-right text-sm">
                 {data[0]?.views !== undefined ? 'Views' : 'Count'}
               </TableHead>
             </TableRow>
@@ -83,18 +61,18 @@ export function RealtimeTable({
           <TableBody>
             {data.map((item, index) => (
               <TableRow key={index}>
-                <TableCell className="font-medium">
+                <TableCell className="py-3 text-sm font-medium">
                   {item.path || item.country || item.name || 'Unknown'}
                 </TableCell>
-                <TableCell className="text-right">
+                <TableCell className="py-3 text-right text-sm tabular-nums">
                   {(item.views || item.count || 0).toLocaleString()}
                 </TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
-      </CardContent>
-    </Card>
+      )}
+    </SectionCard>
   );
 }
 
@@ -108,7 +86,8 @@ export function ActivePagesTable({
 }) {
   return (
     <RealtimeTable
-      title="Most Active Pages (Last Hour)"
+      title="Most Active Pages"
+      description="Last hour"
       data={data}
       loading={loading}
       emptyMessage="No active pages in the last hour"
@@ -125,7 +104,8 @@ export function RecentCountriesTable({
 }) {
   return (
     <RealtimeTable
-      title="Recent Countries (Last Hour)"
+      title="Recent Countries"
+      description="Last hour"
       data={data}
       loading={loading}
       emptyMessage="No recent visitors from any countries"

--- a/components/SectionCard.tsx
+++ b/components/SectionCard.tsx
@@ -1,0 +1,51 @@
+import { ChartTitle } from '@/components/charts/ChartTitle';
+import { cn } from '@/lib/utils';
+
+interface SectionCardProps {
+  /** Optional section heading rendered via ChartTitle for consistency */
+  title?: string;
+  description?: string;
+  /** Shows the inline loading spinner next to the title */
+  loading?: boolean;
+  /** Right-aligned header controls (toggles, pickers, ...) */
+  actions?: React.ReactNode;
+  /** Card padding: `lg` (p-6) for primary sections, `md` (p-4) for grid cells */
+  padding?: 'md' | 'lg';
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared card chrome for dashboard sections.
+ *
+ * Every content block across the app (charts, tables, stat tiles) uses this
+ * single surface — `rounded-lg border bg-card` — so pages stay visually
+ * cohesive. Prefer this over hand-rolling `div` shells or the shadcn `Card`
+ * (which carries its own radius/shadow and reads as a different surface).
+ */
+export function SectionCard({
+  title,
+  description,
+  loading,
+  actions,
+  padding = 'lg',
+  className,
+  children,
+}: SectionCardProps) {
+  return (
+    <section
+      className={cn(
+        'rounded-lg border border-border bg-card',
+        padding === 'lg' ? 'p-6' : 'p-4',
+        className,
+      )}
+    >
+      {title && (
+        <ChartTitle title={title} description={description} loading={loading}>
+          {actions}
+        </ChartTitle>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Light/dark theme toggle.
+ *
+ * The current theme class is applied before paint by the inline script in
+ * app/layout.tsx (reading localStorage, falling back to system preference);
+ * this button just flips the class and persists the choice.
+ */
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setIsDark(document.documentElement.classList.contains('dark'));
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    try {
+      localStorage.setItem('theme', next ? 'dark' : 'light');
+    } catch {
+      // Ignore storage failures (private browsing, etc.)
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      className="size-9 text-muted-foreground hover:text-foreground"
+    >
+      {/* Render both icons and cross-fade so the swap animates */}
+      <span className="relative flex size-4 items-center justify-center">
+        <Sun
+          className={`absolute size-4 transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${
+            mounted && isDark
+              ? 'scale-[0.25] opacity-0 blur-[4px]'
+              : 'scale-100 opacity-100 blur-0'
+          }`}
+        />
+        <Moon
+          className={`absolute size-4 transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${
+            mounted && isDark
+              ? 'scale-100 opacity-100 blur-0'
+              : 'scale-[0.25] opacity-0 blur-[4px]'
+          }`}
+        />
+      </span>
+    </Button>
+  );
+}

--- a/components/charts/ActivityHeatmap.tsx
+++ b/components/charts/ActivityHeatmap.tsx
@@ -44,7 +44,7 @@ export function ActivityHeatmap({
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading activity...</span>
         </div>
@@ -55,9 +55,7 @@ export function ActivityHeatmap({
   if (!data || data.length === 0) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
-          No activity data
-        </div>
+        <div className="text-muted-foreground">No activity data</div>
       </div>
     );
   }

--- a/components/charts/AudienceChart.tsx
+++ b/components/charts/AudienceChart.tsx
@@ -16,7 +16,7 @@ export function AudienceListChart({ data, title, loading }: AudienceListProps) {
   if (loading) {
     return (
       <div className="flex h-72 items-center justify-center">
-        <div className="flex items-center gap-2 text-muted-foreground dark:text-muted-foreground">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading {title.toLowerCase()}...</span>
         </div>
@@ -27,7 +27,7 @@ export function AudienceListChart({ data, title, loading }: AudienceListProps) {
   if (!data || data.length === 0) {
     return (
       <div className="flex h-72 items-center justify-center">
-        <div className="text-sm text-muted-foreground dark:text-muted-foreground">
+        <div className="text-sm text-muted-foreground">
           No {title.toLowerCase()} data in this period
         </div>
       </div>
@@ -46,10 +46,10 @@ export function AudienceListChart({ data, title, loading }: AudienceListProps) {
           return (
             <div key={item.name + index} className="space-y-1">
               <div className="flex items-center justify-between text-xs font-medium">
-                <span className="max-w-[70%] truncate text-foreground dark:text-muted-foreground">
+                <span className="max-w-[70%] truncate text-foreground">
                   {item.name}
                 </span>
-                <span className="shrink-0 text-foreground dark:text-foreground">
+                <span className="shrink-0 text-foreground">
                   {item.value.toLocaleString()}{' '}
                   <span className="font-normal text-muted-foreground">
                     ({item.percentage}%)
@@ -57,9 +57,9 @@ export function AudienceListChart({ data, title, loading }: AudienceListProps) {
                 </span>
               </div>
 
-              <div className="h-2 w-full overflow-hidden rounded-full bg-secondary bg-card">
+              <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
                 <div
-                  className="h-full rounded-full bg-amber-600/80 transition-all duration-500 ease-out"
+                  className="h-full rounded-full bg-chart-3/80 transition-[width] duration-500 ease-out"
                   style={{ width: `${barWidth}%` }}
                 />
               </div>

--- a/components/charts/BotChart.tsx
+++ b/components/charts/BotChart.tsx
@@ -35,11 +35,11 @@ interface BotChartProps {
 }
 
 const COLORS = [
-  '#D97706', // amber (primary)
-  '#0F766E', // teal
-  '#E09145', // warm orange
-  '#7C6FA0', // muted purple
-  '#2B6CB0', // steel blue
+  'hsl(var(--chart-1))', // orange (primary)
+  'hsl(var(--chart-2))', // teal
+  'hsl(var(--chart-3))', // amber
+  'hsl(var(--chart-4))', // muted purple
+  'hsl(var(--chart-5))', // steel blue
   '#65A30D', // lime green
   '#C2410C', // deep orange
   '#0891B2', // cyan
@@ -51,7 +51,7 @@ export function BotOverviewChart({ data, loading }: BotChartProps) {
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading bot analytics...</span>
         </div>
@@ -62,9 +62,7 @@ export function BotOverviewChart({ data, loading }: BotChartProps) {
   if (!data || data.totalPageviews === 0) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
-          No bot data available
-        </div>
+        <div className="text-muted-foreground">No bot data available</div>
       </div>
     );
   }
@@ -75,46 +73,42 @@ export function BotOverviewChart({ data, loading }: BotChartProps) {
       value: data.totalHumans,
       percentage: data.humanPercentage,
       icon: User,
-      color: '#0F766E',
+      color: 'hsl(var(--chart-2))',
     },
     {
       name: 'Bot Traffic',
       value: data.totalBots,
       percentage: data.botPercentage,
       icon: Bot,
-      color: '#C2410C',
+      color: 'hsl(var(--chart-3))',
     },
   ];
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-4">
-        <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-700 dark:bg-neutral-800/50">
+        <div className="rounded-lg border border-border bg-muted/50 p-4">
           <div className="flex items-center gap-2">
-            <User className="size-5 text-teal-600" />
-            <span className="text-sm text-neutral-600 dark:text-neutral-400">
-              Human Traffic
-            </span>
+            <User className="size-5 text-chart-2" />
+            <span className="text-sm text-muted-foreground">Human Traffic</span>
           </div>
-          <p className="mt-2 text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+          <p className="mt-2 text-2xl font-semibold text-foreground">
             {data.totalHumans.toLocaleString()}
           </p>
-          <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          <p className="text-sm text-muted-foreground">
             {data.humanPercentage.toFixed(1)}% of total
           </p>
         </div>
 
-        <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-700 dark:bg-neutral-800/50">
+        <div className="rounded-lg border border-border bg-muted/50 p-4">
           <div className="flex items-center gap-2">
-            <Bot className="size-5 text-orange-700" />
-            <span className="text-sm text-neutral-600 dark:text-neutral-400">
-              Bot Traffic
-            </span>
+            <Bot className="size-5 text-chart-3" />
+            <span className="text-sm text-muted-foreground">Bot Traffic</span>
           </div>
-          <p className="mt-2 text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+          <p className="mt-2 text-2xl font-semibold text-foreground">
             {data.totalBots.toLocaleString()}
           </p>
-          <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          <p className="text-sm text-muted-foreground">
             {data.botPercentage.toFixed(1)}% of total
           </p>
         </div>
@@ -132,7 +126,7 @@ export function BotOverviewChart({ data, loading }: BotChartProps) {
                 `${props.name} (${props.percentage.toFixed(1)}%)`
               }
               outerRadius={80}
-              fill="#D97706"
+              fill="hsl(var(--chart-1))"
               dataKey="value"
             >
               {chartData.map((entry, index) => (
@@ -144,11 +138,11 @@ export function BotOverviewChart({ data, loading }: BotChartProps) {
                 if (active && payload?.length) {
                   const data = payload[0].payload;
                   return (
-                    <div className="rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
-                      <p className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                    <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                      <p className="mb-1 text-sm font-medium text-foreground">
                         {data.name}
                       </p>
-                      <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                      <p className="text-xs text-muted-foreground">
                         {data.value.toLocaleString()} pageviews (
                         {data.percentage.toFixed(1)}%)
                       </p>
@@ -169,7 +163,7 @@ export function BotTypeChart({ data, loading }: BotChartProps) {
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading bot types...</span>
         </div>
@@ -180,9 +174,7 @@ export function BotTypeChart({ data, loading }: BotChartProps) {
   if (!data || data.botsByType.length === 0) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
-          No bot type data
-        </div>
+        <div className="text-muted-foreground">No bot type data</div>
       </div>
     );
   }
@@ -200,7 +192,7 @@ export function BotTypeChart({ data, loading }: BotChartProps) {
               `${props.botType} (${props.percentage.toFixed(1)}%)`
             }
             outerRadius={80}
-            fill="#D97706"
+            fill="hsl(var(--chart-1))"
             dataKey="count"
           >
             {data.botsByType.map((_entry, index) => (
@@ -215,11 +207,11 @@ export function BotTypeChart({ data, loading }: BotChartProps) {
               if (active && payload?.length) {
                 const data = payload[0].payload as BotData;
                 return (
-                  <div className="rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
-                    <p className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {data.botType}
                     </p>
-                    <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                    <p className="text-xs text-muted-foreground">
                       {data.count.toLocaleString()} pageviews (
                       {data.percentage.toFixed(1)}%)
                     </p>
@@ -239,7 +231,7 @@ export function TopBotsChart({ data, loading }: BotChartProps) {
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading top bots...</span>
         </div>
@@ -250,9 +242,7 @@ export function TopBotsChart({ data, loading }: BotChartProps) {
   if (!data || data.topBots.length === 0) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
-          No bot data available
-        </div>
+        <div className="text-muted-foreground">No bot data available</div>
       </div>
     );
   }
@@ -265,33 +255,27 @@ export function TopBotsChart({ data, loading }: BotChartProps) {
           layout="vertical"
           margin={{ top: 5, right: 30, left: 100, bottom: 5 }}
         >
-          <CartesianGrid
-            strokeDasharray="3 3"
-            className="stroke-neutral-200 dark:stroke-neutral-700"
-          />
-          <XAxis
-            type="number"
-            className="text-xs text-neutral-600 dark:text-neutral-400"
-          />
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+          <XAxis type="number" className="text-xs text-muted-foreground" />
           <YAxis
             type="category"
             dataKey="botName"
             width={90}
-            className="text-xs text-neutral-600 dark:text-neutral-400"
+            className="text-xs text-muted-foreground"
           />
           <Tooltip
             content={({ active, payload }) => {
               if (active && payload?.length) {
                 const data = payload[0].payload as BotData;
                 return (
-                  <div className="rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
-                    <p className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {data.botName}
                     </p>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                    <p className="text-xs text-muted-foreground">
                       {data.botType}
                     </p>
-                    <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       {data.count.toLocaleString()} pageviews (
                       {data.percentage.toFixed(1)}%)
                     </p>
@@ -301,7 +285,11 @@ export function TopBotsChart({ data, loading }: BotChartProps) {
               return null;
             }}
           />
-          <Bar dataKey="count" fill="#D97706" radius={[0, 4, 4, 0]} />
+          <Bar
+            dataKey="count"
+            fill="hsl(var(--chart-1))"
+            radius={[0, 4, 4, 0]}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/components/charts/DeviceChart.tsx
+++ b/components/charts/DeviceChart.tsx
@@ -10,11 +10,11 @@ interface DeviceChartProps {
 }
 
 const COLORS = [
-  '#D97706', // amber (primary)
-  '#0F766E', // teal
-  '#E09145', // warm orange
-  '#7C6FA0', // muted purple
-  '#2B6CB0', // steel blue
+  'hsl(var(--chart-1))', // orange (primary)
+  'hsl(var(--chart-2))', // teal
+  'hsl(var(--chart-3))', // amber
+  'hsl(var(--chart-4))', // muted purple
+  'hsl(var(--chart-5))', // steel blue
   '#65A30D', // lime green
   '#C2410C', // deep orange
   '#0891B2', // cyan
@@ -26,7 +26,7 @@ export function DeviceChart({ data, title, loading }: DeviceChartProps) {
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading {title.toLowerCase()}...</span>
         </div>
@@ -75,7 +75,7 @@ export function DeviceChart({ data, title, loading }: DeviceChartProps) {
             labelLine={false}
             label={(entry: any) => `${entry.name} (${entry.percentage}%)`}
             outerRadius={80}
-            fill="#D97706"
+            fill="hsl(var(--chart-1))"
             dataKey="value"
           >
             {chartData.map((_entry, index) => (
@@ -90,11 +90,11 @@ export function DeviceChart({ data, title, loading }: DeviceChartProps) {
               if (active && payload?.length) {
                 const data = payload[0].payload;
                 return (
-                  <div className="rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
-                    <p className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {data.name}
                     </p>
-                    <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                    <p className="text-xs text-muted-foreground">
                       {data.value.toLocaleString()} visits ({data.percentage}%)
                     </p>
                   </div>

--- a/components/charts/DeviceHorizontalChart.tsx
+++ b/components/charts/DeviceHorizontalChart.tsx
@@ -7,11 +7,11 @@ interface DeviceHorizontalChartProps {
 }
 
 const COLORS = [
-  '#D97706', // amber (primary)
-  '#0F766E', // teal
-  '#E09145', // warm orange
-  '#7C6FA0', // muted purple
-  '#2B6CB0', // steel blue
+  'hsl(var(--chart-1))', // orange (primary)
+  'hsl(var(--chart-2))', // teal
+  'hsl(var(--chart-3))', // amber
+  'hsl(var(--chart-4))', // muted purple
+  'hsl(var(--chart-5))', // steel blue
   '#65A30D', // lime green
   '#C2410C', // deep orange
   '#0891B2', // cyan
@@ -27,7 +27,7 @@ export function DeviceHorizontalChart({
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
+        <div className="text-muted-foreground">
           Loading {title.toLowerCase()}...
         </div>
       </div>
@@ -37,7 +37,7 @@ export function DeviceHorizontalChart({
   if (!data || data.length === 0) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
+        <div className="text-muted-foreground">
           No {title.toLowerCase()} data
         </div>
       </div>
@@ -60,19 +60,15 @@ export function DeviceHorizontalChart({
         // If bar is wide enough, value might be on colored background
         const valueOnBar = percentage > 75;
 
-        const labelColor = labelOnBar
-          ? 'text-white'
-          : 'text-neutral-900 dark:text-neutral-100';
-        const valueColor = valueOnBar
-          ? 'text-white'
-          : 'text-neutral-900 dark:text-neutral-100';
+        const labelColor = labelOnBar ? 'text-white' : 'text-foreground';
+        const valueColor = valueOnBar ? 'text-white' : 'text-foreground';
 
         return (
           <div key={index} className="group">
-            <div className="relative h-9 overflow-hidden rounded-md bg-neutral-100 dark:bg-neutral-800">
+            <div className="relative h-9 overflow-hidden rounded-md bg-muted">
               {/* Colored background bar */}
               <div
-                className="absolute inset-0 transition-all"
+                className="absolute inset-0 transition-[width]"
                 style={{
                   width: `${percentage}%`,
                   backgroundColor: color,

--- a/components/charts/DomainTrendsBarChart.tsx
+++ b/components/charts/DomainTrendsBarChart.tsx
@@ -24,9 +24,7 @@ export function DomainTrendsBarChart({
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
-          Loading trends...
-        </div>
+        <div className="text-muted-foreground">Loading trends...</div>
       </div>
     );
   }
@@ -34,9 +32,7 @@ export function DomainTrendsBarChart({
   if (!data || data.length === 0) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
-          No data available
-        </div>
+        <div className="text-muted-foreground">No data available</div>
       </div>
     );
   }
@@ -55,13 +51,13 @@ export function DomainTrendsBarChart({
           <XAxis
             dataKey="formattedDate"
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-neutral-600 dark:text-neutral-400"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
           />
           <YAxis
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-neutral-600 dark:text-neutral-400"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
           />
@@ -69,21 +65,18 @@ export function DomainTrendsBarChart({
             content={({ active, payload, label }) => {
               if (active && payload?.length) {
                 return (
-                  <div className="rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
-                    <p className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {label}
                     </p>
                     {payload.map((entry, index) => (
-                      <p
-                        key={index}
-                        className="text-xs text-neutral-600 dark:text-neutral-400"
-                      >
+                      <p key={index} className="text-xs text-muted-foreground">
                         <span
                           className="mr-1.5 inline-block size-3 rounded-sm"
                           style={{ backgroundColor: entry.color }}
                         ></span>
                         {entry.name}:{' '}
-                        <span className="font-medium text-neutral-900 dark:text-neutral-100">
+                        <span className="font-medium text-foreground">
                           {entry.value?.toLocaleString()}
                         </span>
                       </p>
@@ -97,7 +90,9 @@ export function DomainTrendsBarChart({
           />
           <Bar
             dataKey={isPageViewsMode ? 'pageviews' : 'uniqueVisitors'}
-            fill={isPageViewsMode ? '#D97706' : '#0F766E'}
+            fill={
+              isPageViewsMode ? 'hsl(var(--chart-1))' : 'hsl(var(--chart-2))'
+            }
             radius={[4, 4, 0, 0]}
             name={isPageViewsMode ? 'Page Views' : 'Unique Visitors'}
             isAnimationActive={false}

--- a/components/charts/LocationChart.tsx
+++ b/components/charts/LocationChart.tsx
@@ -20,7 +20,7 @@ export function LocationChart({ data, title, loading }: LocationChartProps) {
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading {title.toLowerCase()}...</span>
         </div>
@@ -31,7 +31,7 @@ export function LocationChart({ data, title, loading }: LocationChartProps) {
   if (!data || data.length === 0) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-neutral-600 dark:text-neutral-400">
+        <div className="text-muted-foreground">
           No {title.toLowerCase()} data
         </div>
       </div>
@@ -56,13 +56,13 @@ export function LocationChart({ data, title, loading }: LocationChartProps) {
         >
           <CartesianGrid
             strokeDasharray="3 3"
-            className="stroke-neutral-200 dark:stroke-neutral-700"
+            className="stroke-border"
             opacity={0.5}
           />
           <XAxis
             type="number"
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-neutral-600 dark:text-neutral-400"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
           />
@@ -70,7 +70,7 @@ export function LocationChart({ data, title, loading }: LocationChartProps) {
             type="category"
             dataKey="name"
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-neutral-600 dark:text-neutral-400"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
             width={80}
@@ -80,11 +80,11 @@ export function LocationChart({ data, title, loading }: LocationChartProps) {
               if (active && payload?.length) {
                 const data = payload[0].payload;
                 return (
-                  <div className="rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
-                    <p className="mb-1 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {label}
                     </p>
-                    <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                    <p className="text-xs text-muted-foreground">
                       {data.value.toLocaleString()} visits ({data.percentage}%)
                     </p>
                   </div>
@@ -93,7 +93,11 @@ export function LocationChart({ data, title, loading }: LocationChartProps) {
               return null;
             }}
           />
-          <Bar dataKey="value" fill="#D97706" radius={[0, 6, 6, 0]} />
+          <Bar
+            dataKey="value"
+            fill="hsl(var(--chart-1))"
+            radius={[0, 6, 6, 0]}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/components/charts/LocationMap.tsx
+++ b/components/charts/LocationMap.tsx
@@ -86,7 +86,7 @@ export function LocationMap({ data, loading }: LocationMapProps) {
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-muted-foreground dark:text-muted-foreground">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading location data...</span>
         </div>
@@ -130,26 +130,22 @@ export function LocationMap({ data, loading }: LocationMapProps) {
         {colorScale.map((item, index) => (
           <div
             key={index}
-            className={`group relative cursor-default rounded-lg border border-border p-3 transition-all hover:scale-105 hover:shadow-md dark:border-border ${getColor(item.intensity)}`}
+            className={`group relative cursor-default rounded-lg border border-border p-3 transition-[transform,box-shadow] hover:scale-105 hover:shadow-md ${getColor(item.intensity)}`}
           >
             <div className="flex flex-col items-center gap-1">
-              <div className="text-lg font-bold text-foreground dark:text-foreground">
+              <div className="text-lg font-bold text-foreground">
                 {item.country}
               </div>
-              <div className="text-2xl font-bold text-indigo-900 dark:text-indigo-100">
+              <div className="text-2xl font-bold tabular-nums text-foreground">
                 {item.count.toLocaleString()}
               </div>
-              <div className="text-xs text-foreground dark:text-muted-foreground">
-                views
-              </div>
+              <div className="text-xs text-muted-foreground">views</div>
             </div>
 
             {/* Tooltip on hover */}
-            <div className="pointer-events-none absolute -top-12 left-1/2 z-10 hidden -translate-x-1/2 rounded-lg border border-border bg-card px-3 py-2 text-sm shadow-lg group-hover:block dark:border-border bg-card">
-              <div className="font-medium text-foreground dark:text-foreground">
-                {item.name}
-              </div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground">
+            <div className="pointer-events-none absolute -top-12 left-1/2 z-10 hidden -translate-x-1/2 rounded-lg border border-border bg-popover px-3 py-2 text-sm shadow-lg group-hover:block">
+              <div className="font-medium text-foreground">{item.name}</div>
+              <div className="text-xs text-muted-foreground">
                 {item.count.toLocaleString()} visits
               </div>
             </div>
@@ -158,7 +154,7 @@ export function LocationMap({ data, loading }: LocationMapProps) {
       </div>
 
       {/* Legend */}
-      <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground dark:text-muted-foreground">
+      <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
         <span>Less traffic</span>
         <div className="flex gap-1">
           {[0, 1, 2, 3, 4, 5, 6].map((i) => (

--- a/components/charts/RadialDonutChart.tsx
+++ b/components/charts/RadialDonutChart.tsx
@@ -12,11 +12,11 @@ interface RadialDonutChartProps {
 }
 
 const COLORS = [
-  '#D97706', // amber (primary)
-  '#0F766E', // teal
-  '#E09145', // warm orange
-  '#7C6FA0', // muted purple
-  '#2B6CB0', // steel blue
+  'hsl(var(--chart-1))', // orange (primary)
+  'hsl(var(--chart-2))', // teal
+  'hsl(var(--chart-3))', // amber
+  'hsl(var(--chart-4))', // muted purple
+  'hsl(var(--chart-5))', // steel blue
   '#65A30D', // lime green
   '#C2410C', // deep orange
   '#0891B2', // cyan
@@ -90,7 +90,7 @@ export function RadialDonutChart({
             paddingAngle={2}
             labelLine={false}
             label={false}
-            fill="#D97706"
+            fill="hsl(var(--chart-1))"
             dataKey="value"
             stroke="none"
           >

--- a/components/charts/RealtimeChart.tsx
+++ b/components/charts/RealtimeChart.tsx
@@ -19,9 +19,7 @@ export function RealtimeChart({ data, loading }: RealtimeChartProps) {
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <div className="text-muted-foreground dark:text-muted-foreground">
-          Loading real-time data...
-        </div>
+        <div className="text-muted-foreground">Loading real-time data...</div>
       </div>
     );
   }
@@ -42,20 +40,20 @@ export function RealtimeChart({ data, loading }: RealtimeChartProps) {
         <LineChart data={data}>
           <CartesianGrid
             strokeDasharray="3 3"
-            className="stroke-neutral-200 dark:stroke-neutral-700"
+            className="stroke-border"
             opacity={0.5}
           />
           <XAxis
             dataKey="hour"
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
             interval="preserveStartEnd"
           />
           <YAxis
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
           />
@@ -63,17 +61,17 @@ export function RealtimeChart({ data, loading }: RealtimeChartProps) {
             content={({ active, payload, label }) => {
               if (active && payload?.length) {
                 return (
-                  <div className="rounded-lg border border-border bg-card p-3 shadow-lg dark:border-border bg-card">
-                    <p className="mb-1 text-sm font-medium text-foreground dark:text-foreground">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {label}
                     </p>
-                    <p className="text-xs text-muted-foreground dark:text-muted-foreground">
+                    <p className="text-xs text-muted-foreground">
                       <span
                         className="mr-1.5 inline-block size-3 rounded-full"
                         style={{ backgroundColor: payload[0].color }}
                       ></span>
                       Views:{' '}
-                      <span className="font-medium text-foreground dark:text-foreground">
+                      <span className="font-medium text-foreground">
                         {payload[0].value?.toLocaleString()}
                       </span>
                     </p>
@@ -86,10 +84,10 @@ export function RealtimeChart({ data, loading }: RealtimeChartProps) {
           <Line
             type="monotone"
             dataKey="views"
-            stroke="#D97706"
+            stroke="hsl(var(--chart-1))"
             strokeWidth={2.5}
             dot={false}
-            activeDot={{ r: 4, fill: '#D97706', strokeWidth: 0 }}
+            activeDot={{ r: 4, fill: 'hsl(var(--chart-1))', strokeWidth: 0 }}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/components/charts/TrendsChart.tsx
+++ b/components/charts/TrendsChart.tsx
@@ -44,7 +44,7 @@ export function TrendsChart({
   if (loading) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="flex items-center gap-2 text-muted-foreground dark:text-muted-foreground">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
           <span>Loading trends...</span>
         </div>
@@ -55,9 +55,7 @@ export function TrendsChart({
   if (!data || data.length === 0) {
     return (
       <div className="flex h-80 items-center justify-center">
-        <div className="text-muted-foreground dark:text-muted-foreground">
-          No data available
-        </div>
+        <div className="text-muted-foreground">No data available</div>
       </div>
     );
   }
@@ -70,12 +68,12 @@ export function TrendsChart({
   const metricConfig = {
     pageviews: {
       label: 'Page Views',
-      color: '#D97706',
+      color: 'hsl(var(--chart-1))',
       dataKey: 'pageviews',
     },
     uniqueVisitors: {
       label: 'Unique Visitors',
-      color: '#0F766E',
+      color: 'hsl(var(--chart-2))',
       dataKey: 'uniqueVisitors',
     },
   };
@@ -88,19 +86,19 @@ export function TrendsChart({
         <BarChart data={chartData}>
           <CartesianGrid
             strokeDasharray="3 3"
-            className="stroke-neutral-200 dark:stroke-neutral-700"
+            className="stroke-border"
             opacity={0.5}
           />
           <XAxis
             dataKey="formattedDate"
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
           />
           <YAxis
             tick={{ fontSize: 12, fill: 'currentColor' }}
-            className="text-muted-foreground dark:text-muted-foreground"
+            className="text-muted-foreground"
             tickLine={false}
             axisLine={false}
           />
@@ -108,17 +106,17 @@ export function TrendsChart({
             content={({ active, payload, label }) => {
               if (active && payload?.length) {
                 return (
-                  <div className="rounded-lg border border-border bg-card p-3 shadow-lg dark:border-border bg-card">
-                    <p className="mb-1 text-sm font-medium text-foreground dark:text-foreground">
+                  <div className="rounded-lg border border-border bg-popover p-3 shadow-lg">
+                    <p className="mb-1 text-sm font-medium text-foreground">
                       {label}
                     </p>
-                    <p className="text-xs text-muted-foreground dark:text-muted-foreground">
+                    <p className="text-xs text-muted-foreground">
                       <span
                         className="mr-1.5 inline-block size-3 rounded-sm"
                         style={{ backgroundColor: currentConfig.color }}
                       ></span>
                       {currentConfig.label}:{' '}
-                      <span className="font-medium text-foreground dark:text-foreground">
+                      <span className="font-medium text-foreground">
                         {payload[0]?.value?.toLocaleString()}
                       </span>
                     </p>
@@ -155,13 +153,13 @@ export function MetricToggle({
   totalUniqueVisitors,
 }: MetricToggleProps) {
   return (
-    <div className="inline-flex items-center gap-1 rounded-md border border-border bg-muted p-0.5 dark:border-border ">
+    <div className="inline-flex items-center gap-1 rounded-md border border-border bg-muted p-0.5">
       <button
         onClick={() => onMetricChange('pageviews')}
         className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
           activeMetric === 'pageviews'
-            ? 'bg-card text-foreground shadow-sm dark:bg-neutral-700 dark:text-foreground'
-            : 'text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground'
+            ? 'bg-card text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
         }`}
       >
         Page Views
@@ -175,8 +173,8 @@ export function MetricToggle({
         onClick={() => onMetricChange('uniqueVisitors')}
         className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
           activeMetric === 'uniqueVisitors'
-            ? 'bg-card text-foreground shadow-sm dark:bg-neutral-700 dark:text-foreground'
-            : 'text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground'
+            ? 'bg-card text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
         }`}
       >
         Unique Visitors

--- a/components/domain/DomainAnalyticsSection.tsx
+++ b/components/domain/DomainAnalyticsSection.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import type { DateRange } from 'react-day-picker';
-import { ChartTitle } from '@/components/charts/ChartTitle';
 import { DeviceHorizontalChart } from '@/components/charts/DeviceHorizontalChart';
 import { LocationChart } from '@/components/charts/LocationChart';
+import { SectionCard } from '@/components/SectionCard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useDevicesData, useLocationsData } from '@/hooks/useAnalytics';
 
@@ -61,74 +61,74 @@ export function DomainAnalyticsSection({
 
       <TabsContent value="devices" className="space-y-4">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Browsers"
-              description="Most popular"
-              loading={fetchingDevices}
-            />
+          <SectionCard
+            padding="md"
+            title="Browsers"
+            description="Most popular"
+            loading={fetchingDevices}
+          >
             <DeviceHorizontalChart
               data={devicesData.browsers}
               title="Browsers"
               loading={loadingDevices}
             />
-          </div>
+          </SectionCard>
 
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Operating Systems"
-              description="Device OS"
-              loading={fetchingDevices}
-            />
+          <SectionCard
+            padding="md"
+            title="Operating Systems"
+            description="Device OS"
+            loading={fetchingDevices}
+          >
             <DeviceHorizontalChart
               data={devicesData.os}
               title="Operating Systems"
               loading={loadingDevices}
             />
-          </div>
+          </SectionCard>
 
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Device Types"
-              description="Desktop, mobile, tablet"
-              loading={fetchingDevices}
-            />
+          <SectionCard
+            padding="md"
+            title="Device Types"
+            description="Desktop, mobile, tablet"
+            loading={fetchingDevices}
+          >
             <DeviceHorizontalChart
               data={devicesData.devices}
               title="Device Types"
               loading={loadingDevices}
             />
-          </div>
+          </SectionCard>
         </div>
       </TabsContent>
 
       <TabsContent value="locations" className="space-y-4">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Top Countries"
-              description="Visitors by country"
-              loading={fetchingLocations}
-            />
+          <SectionCard
+            padding="md"
+            title="Top Countries"
+            description="Visitors by country"
+            loading={fetchingLocations}
+          >
             <LocationChart
               data={locationsData.countries}
               title="Countries"
               loading={loadingLocations}
             />
-          </div>
+          </SectionCard>
 
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Top Cities"
-              description="Visitors by city"
-              loading={fetchingLocations}
-            />
+          <SectionCard
+            padding="md"
+            title="Top Cities"
+            description="Visitors by city"
+            loading={fetchingLocations}
+          >
             <LocationChart
               data={locationsData.cities}
               title="Cities"
               loading={loadingLocations}
             />
-          </div>
+          </SectionCard>
         </div>
       </TabsContent>
     </Tabs>

--- a/components/domain/DomainHeader.tsx
+++ b/components/domain/DomainHeader.tsx
@@ -1,6 +1,4 @@
-import { ArrowLeft } from 'lucide-react';
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
+import { PageHeader } from '@/components/PageHeader';
 
 interface DomainHeaderProps {
   domain: string;
@@ -16,46 +14,36 @@ export function DomainHeader({
   previewCount,
 }: DomainHeaderProps) {
   return (
-    <div>
-      <Link href="/">
-        <Button variant="ghost" size="sm" className="mb-4 h-8 px-2 text-sm">
-          <ArrowLeft className="mr-2 size-4" />
-          Back
-        </Button>
-      </Link>
-
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-normal tracking-tight text-foreground sm:text-2xl">
-            {domain}
-          </h1>
-          <div className="mt-1 flex flex-col gap-1">
-            <p className="text-sm text-muted-foreground">
-              Domain analytics and URL breakdown
-            </p>
-            {previewCount > 0 && (
-              <p className="text-xs text-muted-foreground">
-                Including {previewCount} preview deployment
-                {previewCount > 1 ? 's' : ''}
-              </p>
-            )}
-          </div>
-        </div>
+    <PageHeader
+      title={domain}
+      description={
+        <>
+          Domain analytics and URL breakdown
+          {previewCount > 0 && (
+            <span className="mt-1 block text-xs">
+              Including {previewCount} preview deployment
+              {previewCount > 1 ? 's' : ''}
+            </span>
+          )}
+        </>
+      }
+      backHref="/"
+      actions={
         <div className="flex gap-6 text-right">
           <div>
-            <div className="text-xl font-medium text-foreground sm:text-2xl">
+            <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
               {totalUrls}
             </div>
             <div className="text-sm text-muted-foreground">Total URLs</div>
           </div>
           <div>
-            <div className="text-xl font-medium text-foreground sm:text-2xl">
+            <div className="text-xl font-medium tabular-nums text-foreground sm:text-2xl">
               {totalPageviews.toLocaleString()}
             </div>
             <div className="text-sm text-muted-foreground">Total Views</div>
           </div>
         </div>
-      </div>
-    </div>
+      }
+    />
   );
 }

--- a/components/domain/DomainTrendsSection.tsx
+++ b/components/domain/DomainTrendsSection.tsx
@@ -2,9 +2,9 @@ import { format } from 'date-fns';
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 import type { TrendData } from '@/app/api/analytics/trends/route';
-import { ChartTitle } from '@/components/charts/ChartTitle';
 import { DomainTrendsBarChart } from '@/components/charts/DomainTrendsBarChart';
 import { DateRangePicker } from '@/components/DateRangePicker';
+import { SectionCard } from '@/components/SectionCard';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export type MetricView = 'pageviews' | 'visitors';
@@ -36,20 +36,17 @@ export function DomainTrendsSection({
   return (
     <>
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div>
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-            {dateRange?.from && dateRange?.to && formatDateRange()}
-          </p>
-        </div>
+        <p className="text-sm text-muted-foreground">
+          {dateRange?.from && dateRange?.to && formatDateRange()}
+        </p>
         <DateRangePicker value={dateRange} onChange={onDateRangeChange} />
       </div>
 
-      <div className="rounded-lg border bg-border bg-card p-6 dark:bg-border ">
-        <ChartTitle
-          title="Traffic Trends"
-          description={`Page views and unique visitors for ${domain}`}
-          loading={fetching}
-        >
+      <SectionCard
+        title="Traffic Trends"
+        description={`Page views and unique visitors for ${domain}`}
+        loading={fetching}
+        actions={
           <Tabs
             value={metricView}
             onValueChange={(value) => setMetricView(value as MetricView)}
@@ -63,13 +60,14 @@ export function DomainTrendsSection({
               </TabsTrigger>
             </TabsList>
           </Tabs>
-        </ChartTitle>
+        }
+      >
         <DomainTrendsBarChart
           data={trendsData}
           loading={loading}
           metricView={metricView}
         />
-      </div>
+      </SectionCard>
     </>
   );
 }

--- a/components/domain/DomainUrlTable.tsx
+++ b/components/domain/DomainUrlTable.tsx
@@ -1,5 +1,7 @@
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Link2 } from 'lucide-react';
 import Link from 'next/link';
+import { EmptyState } from '@/components/EmptyState';
+import { SectionCard } from '@/components/SectionCard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -28,87 +30,78 @@ export function DomainUrlTable({
   urlStats,
   totalPageviews,
 }: DomainUrlTableProps) {
-  if (urlStats.length === 0) {
-    return (
-      <div className="rounded-lg border bg-border bg-card p-6 dark:bg-border ">
-        <div className="mb-4">
-          <h2 className="text-sm font-medium text-foreground dark:text-foreground sm:text-base">
-            URLs
-          </h2>
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-            All tracked URLs for this domain sorted by pageviews
-          </p>
-        </div>
-        <div className="py-12 text-center text-sm text-muted-foreground dark:text-muted-foreground">
-          <p>No URLs tracked yet</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="rounded-lg border bg-border bg-card p-6 dark:bg-border ">
-      <div className="mb-4">
-        <h2 className="text-sm font-medium text-foreground dark:text-foreground sm:text-base">
-          URLs
-        </h2>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-          All tracked URLs for this domain sorted by pageviews
-        </p>
-      </div>
-      <Table>
-        <TableHeader>
-          <TableRow className="hover:bg-transparent">
-            <TableHead className="h-10 text-sm">URL</TableHead>
-            <TableHead className="h-10 text-right text-sm">Pageviews</TableHead>
-            <TableHead className="h-10 text-right text-sm">Share</TableHead>
-            <TableHead className="h-10 w-[80px]"></TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {urlStats.map((urlStat) => {
-            const percentage =
-              totalPageviews > 0
-                ? ((urlStat._count.pageViews / totalPageviews) * 100).toFixed(1)
-                : 0;
+    <SectionCard
+      title="URLs"
+      description="All tracked URLs for this domain sorted by pageviews"
+    >
+      {urlStats.length === 0 ? (
+        <EmptyState
+          icon={Link2}
+          title="No URLs tracked yet"
+          description="URLs will appear here once pageviews are recorded for this domain"
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="h-10 text-sm">URL</TableHead>
+              <TableHead className="h-10 text-right text-sm">
+                Pageviews
+              </TableHead>
+              <TableHead className="h-10 text-right text-sm">Share</TableHead>
+              <TableHead className="h-10 w-[80px]"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {urlStats.map((urlStat) => {
+              const percentage =
+                totalPageviews > 0
+                  ? ((urlStat._count.pageViews / totalPageviews) * 100).toFixed(
+                      1,
+                    )
+                  : 0;
 
-            return (
-              <TableRow key={urlStat.id} className="group">
-                <TableCell className="max-w-[500px] py-3 font-mono text-sm">
-                  <a
-                    href={urlStat.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 text-foreground hover:text-primary hover:underline dark:text-foreground/80"
-                  >
-                    <span className="truncate">{urlStat.url}</span>
-                    <ExternalLink className="size-3 shrink-0 opacity-40" />
-                  </a>
-                </TableCell>
-                <TableCell className="py-3 text-right text-sm font-medium">
-                  {urlStat._count.pageViews.toLocaleString()}
-                </TableCell>
-                <TableCell className="py-3 text-right">
-                  <Badge variant="secondary" className="h-5 px-2 text-xs">
-                    {percentage}%
-                  </Badge>
-                </TableCell>
-                <TableCell className="py-3 text-right">
-                  <Link href={`/url/${urlStat.id}`}>
+              return (
+                <TableRow key={urlStat.id} className="group">
+                  <TableCell className="max-w-[500px] py-3 font-mono text-sm">
+                    <a
+                      href={urlStat.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1.5 text-foreground hover:text-primary hover:underline"
+                    >
+                      <span className="truncate">{urlStat.url}</span>
+                      <ExternalLink className="size-3 shrink-0 opacity-40" />
+                    </a>
+                  </TableCell>
+                  <TableCell className="py-3 text-right text-sm font-medium tabular-nums">
+                    {urlStat._count.pageViews.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="py-3 text-right">
+                    <Badge
+                      variant="secondary"
+                      className="h-5 px-2 text-xs tabular-nums"
+                    >
+                      {percentage}%
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="py-3 text-right">
                     <Button
+                      asChild
                       variant="outline"
                       size="sm"
                       className="h-7 px-3 text-xs"
                     >
-                      View
+                      <Link href={`/url/${urlStat.id}`}>View</Link>
                     </Button>
-                  </Link>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </SectionCard>
   );
 }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-9 items-center justify-center rounded-lg bg-neutral-100 p-1 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400',
+      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm dark:data-[state=active]:bg-neutral-700 dark:data-[state=active]:text-neutral-100',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-[color,background-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}

--- a/components/url/UrlAnalyticsSection.tsx
+++ b/components/url/UrlAnalyticsSection.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import type { DateRange } from 'react-day-picker';
-import { ChartTitle } from '@/components/charts/ChartTitle';
 import { DeviceHorizontalChart } from '@/components/charts/DeviceHorizontalChart';
 import { LocationChart } from '@/components/charts/LocationChart';
+import { SectionCard } from '@/components/SectionCard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useDevicesData, useLocationsData } from '@/hooks/useAnalytics';
 
@@ -61,74 +61,74 @@ export function UrlAnalyticsSection({
 
       <TabsContent value="devices" className="space-y-4">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Browsers"
-              description="Most popular"
-              loading={fetchingDevices}
-            />
+          <SectionCard
+            padding="md"
+            title="Browsers"
+            description="Most popular"
+            loading={fetchingDevices}
+          >
             <DeviceHorizontalChart
               data={devicesData.browsers}
               title="Browsers"
               loading={loadingDevices}
             />
-          </div>
+          </SectionCard>
 
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Operating Systems"
-              description="Device OS"
-              loading={fetchingDevices}
-            />
+          <SectionCard
+            padding="md"
+            title="Operating Systems"
+            description="Device OS"
+            loading={fetchingDevices}
+          >
             <DeviceHorizontalChart
               data={devicesData.os}
               title="Operating Systems"
               loading={loadingDevices}
             />
-          </div>
+          </SectionCard>
 
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Device Types"
-              description="Desktop, mobile, tablet"
-              loading={fetchingDevices}
-            />
+          <SectionCard
+            padding="md"
+            title="Device Types"
+            description="Desktop, mobile, tablet"
+            loading={fetchingDevices}
+          >
             <DeviceHorizontalChart
               data={devicesData.devices}
               title="Device Types"
               loading={loadingDevices}
             />
-          </div>
+          </SectionCard>
         </div>
       </TabsContent>
 
       <TabsContent value="locations" className="space-y-4">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Top Countries"
-              description="Visitors by country"
-              loading={fetchingLocations}
-            />
+          <SectionCard
+            padding="md"
+            title="Top Countries"
+            description="Visitors by country"
+            loading={fetchingLocations}
+          >
             <LocationChart
               data={locationsData.countries}
               title="Countries"
               loading={loadingLocations}
             />
-          </div>
+          </SectionCard>
 
-          <div className="rounded-lg border bg-border bg-card p-4 dark:bg-border ">
-            <ChartTitle
-              title="Top Cities"
-              description="Visitors by city"
-              loading={fetchingLocations}
-            />
+          <SectionCard
+            padding="md"
+            title="Top Cities"
+            description="Visitors by city"
+            loading={fetchingLocations}
+          >
             <LocationChart
               data={locationsData.cities}
               title="Cities"
               loading={loadingLocations}
             />
-          </div>
+          </SectionCard>
         </div>
       </TabsContent>
     </Tabs>

--- a/components/url/UrlTrendsSection.tsx
+++ b/components/url/UrlTrendsSection.tsx
@@ -2,9 +2,9 @@ import { format } from 'date-fns';
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 import type { TrendData } from '@/app/api/analytics/trends/route';
-import { ChartTitle } from '@/components/charts/ChartTitle';
 import { DomainTrendsBarChart } from '@/components/charts/DomainTrendsBarChart';
 import { DateRangePicker } from '@/components/DateRangePicker';
+import { SectionCard } from '@/components/SectionCard';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export type MetricView = 'pageviews' | 'visitors';
@@ -38,20 +38,17 @@ export function UrlTrendsSection({
   return (
     <>
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div>
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-            {dateRange?.from && dateRange?.to && formatDateRange()}
-          </p>
-        </div>
+        <p className="text-sm text-muted-foreground">
+          {dateRange?.from && dateRange?.to && formatDateRange()}
+        </p>
         <DateRangePicker value={dateRange} onChange={onDateRangeChange} />
       </div>
 
-      <div className="rounded-lg border bg-border bg-card p-6 dark:bg-border ">
-        <ChartTitle
-          title="Traffic Trends"
-          description={`Page views and unique visitors for this URL`}
-          loading={fetching}
-        >
+      <SectionCard
+        title="Traffic Trends"
+        description="Page views and unique visitors for this URL"
+        loading={fetching}
+        actions={
           <Tabs
             value={metricView}
             onValueChange={(value) => setMetricView(value as MetricView)}
@@ -65,13 +62,14 @@ export function UrlTrendsSection({
               </TabsTrigger>
             </TabsList>
           </Tabs>
-        </ChartTitle>
+        }
+      >
         <DomainTrendsBarChart
           data={trendsData}
           loading={loading}
           metricView={metricView}
         />
-      </div>
+      </SectionCard>
     </>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ['class'],
+  // `.dark` never appears literally in content files (it's applied at runtime
+  // by the theme toggle), so safelist it or Tailwind tree-shakes the
+  // `.dark { --background: ... }` token block out of the compiled CSS.
+  safelist: ['dark'],
   content: [
     'pages/**/*.{ts,tsx}',
     'components/**/*.{ts,tsx}',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,13 @@ module.exports = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        chart: {
+          1: 'hsl(var(--chart-1))',
+          2: 'hsl(var(--chart-2))',
+          3: 'hsl(var(--chart-3))',
+          4: 'hsl(var(--chart-4))',
+          5: 'hsl(var(--chart-5))',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary

Presentation-layer redesign that raises every page to one consistent shadcn/ui-based design system. No backend/API/tracking/DB changes.

### New shared components
- **`SectionCard`** — the single card surface (`rounded-lg border bg-card`, `p-4`/`p-6` variants, optional `ChartTitle` header). Replaces ~30 hand-rolled `div` shells and the mixed use of shadcn `Card` (which carried a different radius/shadow) so all five pages share identical chrome.
- **`PageHeader`** — unified title / description / back-link / header-actions treatment across Analytics, Real-time, Domain, and URL pages.
- **`ThemeToggle`** — light/dark toggle in the header (sun/moon cross-fade; no new dependency).

### Real bugs fixed along the way
- **Dark mode never actually worked.** Tailwind v3 tree-shakes custom `@layer base` rules whose class doesn't appear in content files — since nothing ever set `.dark`, the entire `.dark { --background: … }` token block was missing from the compiled CSS. Fixed with `safelist: ['dark']`, a pre-paint theme bootstrap script (localStorage → `prefers-color-scheme` fallback), and the new header toggle.
- **Dark-mode card bug**: 15 section shells carried `border bg-border bg-card … dark:bg-border`, painting card surfaces with the border color in dark mode.
- **`ui/tabs.tsx` had drifted from stock shadcn** with hardcoded `neutral-*`/`bg-white` classes (cold gray inside the warm Anthropic palette) — restored token-based styling.
- **Hydration failure on `/realtime`** (`useState(new Date())` server/client mismatch) which forced a full client re-render — and wiped the `dark` class.

### Consistency & polish
- Registered `chart-1..5` Tailwind color aliases; chart series, categorical palettes, tooltips (`bg-popover`), grid strokes, loading/empty states now all use theme tokens instead of hardcoded `neutral-*`/hex — charts finally adapt to dark mode.
- Semantic states: bots filter is now a shadcn `Toggle` (primary tokens, was hardcoded indigo); realtime live/offline is one cohesive badge with a pulsing dot (was mixed green/red icons + badge); error panel uses `destructive` tokens + `role="alert"`.
- Loading via the `Skeleton` primitive (was ad-hoc `animate-pulse` divs); `EmptyState` reused for empty tables.
- A11y/micro-interactions: focus-visible rings + larger hit areas on sort headers, `aria-expanded` + rotating chevron on the integration guide, `Button asChild` instead of nested `Link>Button`, `tabular-nums` on numeric columns, subtle favicon outlines, `transition-all` replaced with specific properties throughout.

## Verification

- `yarn lint` ✅ (0 errors; warnings 165 → 160)
- `yarn type-check` ✅
- `yarn test` ✅ 36/36
- `yarn build` ✅
- **Live browser check**: ran the app against a local seeded Postgres and screenshotted all five pages (/, /analytics, /realtime, /domain/:d, /url/:id) with Playwright in **both light and dark** mode — verified cohesive chrome, working dark tokens, live-tracking still recording pageviews, and no page errors after the hydration fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vP4zhjjwLqUxW3sUBiWuP

---
_Generated by [Claude Code](https://claude.ai/code/session_016vP4zhjjwLqUxW3sUBiWuP)_